### PR TITLE
update GitHub Desktop Linux fork to latest public release

### DIFF
--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -14,12 +14,12 @@ version = "1.53.0"
 
 [[direct]]
 name = "github-desktop"
-version = "2.4.1-linux1"
+version = "2.7.2-linux1"
 
     [[direct.urls]]
     arch = "amd64"
     url = "https://github.com/shiftkey/desktop/releases/download/release-${version}/GitHubDesktop-linux-${version}.deb"
-    checksum = "5339a240b549656cfcf948d98002f03842914d7eaa6ed0548e352e30ffa4b683"
+    checksum = "24ab3159956388b5c548de8bb787244a4e0c59c2ba32bfbaad1a07acd7f5b3f1"
 
 # [[source]]
 # name = "piserver"

--- a/suites/groovy.toml
+++ b/suites/groovy.toml
@@ -14,12 +14,12 @@ version = "1.53.0"
 
 [[direct]]
 name = "github-desktop"
-version = "2.4.1-linux1"
+version = "2.7.2-linux1"
 
     [[direct.urls]]
     arch = "amd64"
     url = "https://github.com/shiftkey/desktop/releases/download/release-${version}/GitHubDesktop-linux-${version}.deb"
-    checksum = "5339a240b549656cfcf948d98002f03842914d7eaa6ed0548e352e30ffa4b683"
+    checksum = "24ab3159956388b5c548de8bb787244a4e0c59c2ba32bfbaad1a07acd7f5b3f1"
 
 # [[source]]
 # name = "piserver"

--- a/suites/hirsute.toml
+++ b/suites/hirsute.toml
@@ -14,12 +14,12 @@ version = "1.53.0"
 
 [[direct]]
 name = "github-desktop"
-version = "2.4.1-linux1"
+version = "2.7.2-linux1"
 
     [[direct.urls]]
     arch = "amd64"
     url = "https://github.com/shiftkey/desktop/releases/download/release-${version}/GitHubDesktop-linux-${version}.deb"
-    checksum = "5339a240b549656cfcf948d98002f03842914d7eaa6ed0548e352e30ffa4b683"
+    checksum = "24ab3159956388b5c548de8bb787244a4e0c59c2ba32bfbaad1a07acd7f5b3f1"
 
 # [[source]]
 # name = "piserver"


### PR DESCRIPTION
:wave: former GitHub Desktop contributor and current maintainer of the Linux fork

I'm not sure if this is the right place to submit this change, but I've had so many reports of the version of GitHub Desktop that's available on the Pop Store which is unable to login that I need to start somewhere.

An incomplete sample of recent reports:

 - https://github.com/shiftkey/desktop/issues/483
 - https://github.com/shiftkey/desktop/issues/480
 - https://github.com/shiftkey/desktop/issues/466
 - https://github.com/shiftkey/desktop/issues/457
 - https://github.com/shiftkey/desktop/issues/445

The reason for this regression:

> There were GitHub API changes related to authorizations which mean username/password authentication is no longer supported. For more context see the upstream PR https://github.com/desktop/desktop/pull/11006 and the planned deprecation announcement from late 2019 https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/.

If you know of the right place to update this, I'm happy to submit a PR there.