### PR TITLE
update GitHub Desktop to latest release

### DIFF
--- a/suites/bionic.toml
+++ b/suites/bionic.toml
@@ -54,12 +54,12 @@ version = "3.11.2912"
 
 [[direct]]
 name = "github-desktop"
-version = "2.1.0-linux1"
+version = "2.8.1-linux1"
 
     [[direct.urls]]
     arch = "amd64"
-    url = "https://github.com/shiftkey/desktop/releases/download/release-2.1.0-linux1/GitHubDesktop-linux-2.1.0-linux1.deb"
-    checksum = "8dd4cf7ea4df04a245c1b9b49102dc6f060084de52f2fdc44bbf0280ffe40077"
+    url = "https://github.com/shiftkey/desktop/releases/download/release-${version}/GitHubDesktop-linux-${version}.deb"
+    checksum = "bb2006845389587734039c8a6138cd7a78f388dc5ab4c8cd81959cd8206d8041"
 
 # [[source]]
 # name = "piserver"

--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -14,12 +14,12 @@ version = "1.53.0"
 
 [[direct]]
 name = "github-desktop"
-version = "2.7.2-linux1"
+version = "2.8.1-linux1"
 
     [[direct.urls]]
     arch = "amd64"
     url = "https://github.com/shiftkey/desktop/releases/download/release-${version}/GitHubDesktop-linux-${version}.deb"
-    checksum = "24ab3159956388b5c548de8bb787244a4e0c59c2ba32bfbaad1a07acd7f5b3f1"
+    checksum = "bb2006845389587734039c8a6138cd7a78f388dc5ab4c8cd81959cd8206d8041"
 
 # [[source]]
 # name = "piserver"

--- a/suites/groovy.toml
+++ b/suites/groovy.toml
@@ -14,12 +14,12 @@ version = "1.53.0"
 
 [[direct]]
 name = "github-desktop"
-version = "2.7.2-linux1"
+version = "2.8.1-linux1"
 
     [[direct.urls]]
     arch = "amd64"
     url = "https://github.com/shiftkey/desktop/releases/download/release-${version}/GitHubDesktop-linux-${version}.deb"
-    checksum = "24ab3159956388b5c548de8bb787244a4e0c59c2ba32bfbaad1a07acd7f5b3f1"
+    checksum = "bb2006845389587734039c8a6138cd7a78f388dc5ab4c8cd81959cd8206d8041"
 
 # [[source]]
 # name = "piserver"

--- a/suites/hirsute.toml
+++ b/suites/hirsute.toml
@@ -14,12 +14,12 @@ version = "1.53.0"
 
 [[direct]]
 name = "github-desktop"
-version = "2.7.2-linux1"
+version = "2.8.1-linux1"
 
     [[direct.urls]]
     arch = "amd64"
     url = "https://github.com/shiftkey/desktop/releases/download/release-${version}/GitHubDesktop-linux-${version}.deb"
-    checksum = "24ab3159956388b5c548de8bb787244a4e0c59c2ba32bfbaad1a07acd7f5b3f1"
+    checksum = "bb2006845389587734039c8a6138cd7a78f388dc5ab4c8cd81959cd8206d8041"
 
 # [[source]]
 # name = "piserver"


### PR DESCRIPTION
Follow-up to #3 

Release notes:

 - [`2.8.0`](https://github.com/shiftkey/desktop/releases/tag/release-2.8.0-linux1)
 - [`2.8.1`](https://github.com/shiftkey/desktop/releases/tag/release-2.8.1-linux1)

Also spotted the Bionic feed has a very old version, so I've bumped that to the same version to keep them all in sync. I'm not aware of any limitations to supporting this on 18.04 anyway.