### PR TITLE
docs: Add reminder to update VirtualBox extension pack separately

### DIFF
--- a/suites/jammy.toml
+++ b/suites/jammy.toml
@@ -24,6 +24,7 @@ version = "2.8.1-linux1"
 [[direct]]
 name = "virtualbox"
 version = "7.2.6-172322"
+# When updating, remember to also update the extension pack: https://github.com/pop-os/virtualbox-ext-pack
 
     [[direct.urls]]
     arch = "amd64"

--- a/suites/noble.toml
+++ b/suites/noble.toml
@@ -24,6 +24,7 @@ version = "2.8.1-linux1"
 [[direct]]
 name = "virtualbox"
 version = "7.2.6-172322"
+# When updating, remember to also update the extension pack: https://github.com/pop-os/virtualbox-ext-pack
 
     [[direct.urls]]
     arch = "amd64"

--- a/suites/resolute.toml
+++ b/suites/resolute.toml
@@ -24,6 +24,7 @@ version = "2.8.1-linux1"
 [[direct]]
 name = "virtualbox"
 version = "7.2.6-172322"
+# When updating, remember to also update the extension pack: https://github.com/pop-os/virtualbox-ext-pack
 
     [[direct.urls]]
     arch = "amd64"


### PR DESCRIPTION
This should hopefully help us avoid https://github.com/pop-os/virtualbox-ext-pack/issues/5 being re-opened again. Clearly, it's not easy enough to remember that repo exists and needs to be bumped when this package is bumped, so this just adds a reminder to do it.

(It may be possible at some point to fold virtualbox-ext-pack into this repo and update it using the same version number, but this is the quickest solution for now. The reason we don't already just handle virtualbox-ext-pack in this repo or repo-proprietary is because Oracle publishes it as a .vbox-extpack file to be manually opened within VirtualBox, not as a .deb package that we can easily repackage.)