### PR TITLE
fix (VirtualBox): debian/control files

### DIFF
--- a/assets/replace/jammy/main/binary-amd64/virtualbox/files/DEBIAN/control
+++ b/assets/replace/jammy/main/binary-amd64/virtualbox/files/DEBIAN/control
@@ -1,19 +1,17 @@
- Package: virtualbox-7.2
- Version: 7.2.14-174565~Ubuntu~jammy
- Architecture: amd64
- Maintainer: Oracle Corporation <info@virtualbox.org>
- Installed-Size: 273150
- Pre-Depends: debconf (>= 1.1) | debconf-2.0
- Depends: psmisc, adduser, libvulkan1, libatk1.0-0 (>= 1.12.4), libc6 (>= 2.34), libcairo-gobject2 (>= 1.10.0), libcairo2 (>= 1.2.4), libcurl4 (>= 7.16.2), libdbus-1-3 (>= 1.9.14), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.9.1), libgcc-s1 (>= 3.4), libgdk-pixbuf-2.0-0 (>= 2.31.1), libgl1, libglib2.0-0 (>= 2.33.14), libgsoap-2.8.117 (>= 2.8.117), libgtk-3-0 (>= 3.21.5), libgtk2.0-0 (>= 2.24.0), libpango-1.0-0 (>= 1.14.0), libpangocairo-1.0-0 (>= 1.14.0), libpangoft2-1.0-0 (>= 1.14.0), libpng16-16 (>= 1.6.2-1), libssl3 (>= 3.0.0~~alpha1), libstdc++6 (>= 12), libvpx7 (>= 1.10.0), libwayland-client0 (>= 1.11.0), libwayland-cursor0 (>= 1.8.1), libx11-6, libx11-xcb1 (>= 2:1.7.5), libxcb-cursor0 (>= 0.0.99), libxcb-icccm4 (>= 0.4.1), libxcb-image0 (>= 0.2.1), libxcb-keysyms1 (>= 0.4.0), libxcb-randr0 (>= 1.12), libxcb-render-util0, libxcb-render0, libxcb-shape0, libxcb-shm0 (>= 1.10), libxcb-sync1, libxcb-xfixes0, libxcb-xkb1, libxcb1 (>= 1.8), libxkbcommon-x11-0 (>= 0.5.0), libxkbcommon0 (>= 0.5.0), libxml2 (>= 2.7.4), libxt6, zlib1g (>= 1:1.2.3.4)
- Recommends: libasound2, libpulse0, libsdl-ttf2.0-0, kmod | kldutils | module-init-tools, linux-headers-generic | linux-headers-generic-pae | linux-headers-686-pae | linux-headers-amd64 | linux-headers-2.6-686 | linux-headers-2.6-amd64 | linux-headers, linux-image, gcc, make | build-essential | dpkg-dev, binutils, pdf-viewer
- Conflicts: virtualbox, virtualbox-dkms, virtualbox-guest-additions-iso, virtualbox-ose, virtualbox-qt
- Replaces: virtualbox
- Provides: virtualbox
- Section: contrib/misc
- Priority: optional
- Description: Oracle VirtualBox
-  VirtualBox is a powerful PC virtualization solution allowing you to run a
-  wide range of PC operating systems on your Linux system. This includes
-  Windows, Linux, FreeBSD, DOS, OpenBSD and others. VirtualBox comes with a broad
-  feature set and excellent performance, making it the premier virtualization
-  software solution on the market.
+Package: virtualbox
+Version: 7.2.14-174565~Ubuntu~jammy
+Architecture: amd64
+Maintainer: Oracle Corporation <info@virtualbox.org>
+Installed-Size: 273150
+Pre-Depends: debconf (>= 1.1) | debconf-2.0
+Depends: psmisc, adduser, libvulkan1, libatk1.0-0 (>= 1.12.4), libc6 (>= 2.34), libcairo-gobject2 (>= 1.10.0), libcairo2 (>= 1.2.4), libcurl4 (>= 7.16.2), libdbus-1-3 (>= 1.9.14), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.9.1), libgcc-s1 (>= 3.4), libgdk-pixbuf-2.0-0 (>= 2.31.1), libgl1, libglib2.0-0 (>= 2.33.14), libgsoap-2.8.117 (>= 2.8.117), libgtk-3-0 (>= 3.21.5), libgtk2.0-0 (>= 2.24.0), libpango-1.0-0 (>= 1.14.0), libpangocairo-1.0-0 (>= 1.14.0), libpangoft2-1.0-0 (>= 1.14.0), libpng16-16 (>= 1.6.2-1), libssl3 (>= 3.0.0~~alpha1), libstdc++6 (>= 12), libvpx7 (>= 1.10.0), libwayland-client0 (>= 1.11.0), libwayland-cursor0 (>= 1.8.1), libx11-6, libx11-xcb1 (>= 2:1.7.5), libxcb-cursor0 (>= 0.0.99), libxcb-icccm4 (>= 0.4.1), libxcb-image0 (>= 0.2.1), libxcb-keysyms1 (>= 0.4.0), libxcb-randr0 (>= 1.12), libxcb-render-util0, libxcb-render0, libxcb-shape0, libxcb-shm0 (>= 1.10), libxcb-sync1, libxcb-xfixes0, libxcb-xkb1, libxcb1 (>= 1.8), libxkbcommon-x11-0 (>= 0.5.0), libxkbcommon0 (>= 0.5.0), libxml2 (>= 2.7.4), libxt6, zlib1g (>= 1:1.2.3.4)
+Recommends: libasound2, libpulse0, libsdl-ttf2.0-0, kmod | kldutils | module-init-tools, linux-headers-generic | linux-headers-generic-pae | linux-headers-686-pae | linux-headers-amd64 | linux-headers-2.6-686 | linux-headers-2.6-amd64 | linux-headers, linux-image, gcc, make | build-essential | dpkg-dev, binutils, pdf-viewer
+Conflicts: virtualbox-ose
+Section: contrib/misc
+Priority: optional
+Description: Oracle VirtualBox
+ VirtualBox is a powerful PC virtualization solution allowing you to run a
+ wide range of PC operating systems on your Linux system. This includes
+ Windows, Linux, FreeBSD, DOS, OpenBSD and others. VirtualBox comes with a broad
+ feature set and excellent performance, making it the premier virtualization
+ software solution on the market.

--- a/assets/replace/noble/main/binary-amd64/virtualbox/files/DEBIAN/control
+++ b/assets/replace/noble/main/binary-amd64/virtualbox/files/DEBIAN/control
@@ -1,19 +1,17 @@
- Package: virtualbox-7.2
- Version: 7.2.14-174565~Ubuntu~noble
- Architecture: amd64
- Maintainer: Oracle Corporation <info@virtualbox.org>
- Installed-Size: 272266
- Pre-Depends: debconf (>= 1.1) | debconf-2.0
- Depends: psmisc, adduser, libvulkan1, libatk1.0-0t64 (>= 1.12.4), libc6 (>= 2.38), libcairo-gobject2 (>= 1.10.0), libcairo2 (>= 1.2.4), libcurl4t64 (>= 7.16.2), libdbus-1-3 (>= 1.9.14), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.9.1), libgcc-s1 (>= 3.4), libgdk-pixbuf-2.0-0 (>= 2.31.1), libgl1, libglib2.0-0t64 (>= 2.34.0), libgtk-3-0t64 (>= 3.21.5), libgtk2.0-0t64 (>= 2.24.0), liblzf1 (>= 1.5), liblzma5 (>= 5.1.1alpha+20120614), libpango-1.0-0 (>= 1.14.0), libpangocairo-1.0-0 (>= 1.14.0), libpangoft2-1.0-0 (>= 1.14.0), libpng16-16t64 (>= 1.6.2), libssl3t64 (>= 3.0.0), libstdc++6 (>= 13.1), libtpms0 (>= 0.8.0~dev1), libvpx9 (>= 1.12.0), libwayland-client0 (>= 1.11.0), libwayland-cursor0 (>= 1.8.1), libx11-6, libx11-xcb1 (>= 2:1.8.7), libxcb-cursor0 (>= 0.0.99), libxcb-icccm4 (>= 0.4.1), libxcb-image0 (>= 0.2.1), libxcb-keysyms1 (>= 0.4.0), libxcb-randr0 (>= 1.12), libxcb-render-util0, libxcb-render0, libxcb-shape0, libxcb-shm0 (>= 1.10), libxcb-sync1, libxcb-xfixes0, libxcb-xkb1, libxcb1 (>= 1.8), libxkbcommon-x11-0 (>= 0.5.0), libxkbcommon0 (>= 0.5.0), libxml2 (>= 2.7.4), libxt6t64, zlib1g (>= 1:1.2.3.4)
- Recommends: libasound2, libpulse0, libsdl-ttf2.0-0, kmod | kldutils | module-init-tools, linux-headers-generic | linux-headers-generic-pae | linux-headers-686-pae | linux-headers-amd64 | linux-headers-2.6-686 | linux-headers-2.6-amd64 | linux-headers, linux-image, gcc, make | build-essential | dpkg-dev, binutils, pdf-viewer
- Conflicts: virtualbox, virtualbox-dkms, virtualbox-guest-additions-iso, virtualbox-ose, virtualbox-qt
- Replaces: virtualbox
- Provides: virtualbox
- Section: contrib/misc
- Priority: optional
- Description: Oracle VirtualBox
-  VirtualBox is a powerful PC virtualization solution allowing you to run a
-  wide range of PC operating systems on your Linux system. This includes
-  Windows, Linux, FreeBSD, DOS, OpenBSD and others. VirtualBox comes with a broad
-  feature set and excellent performance, making it the premier virtualization
-  software solution on the market
+Package: virtualbox
+Version: 7.2.14-174565~Ubuntu~noble
+Architecture: amd64
+Maintainer: Oracle Corporation <info@virtualbox.org>
+Installed-Size: 272266
+Pre-Depends: debconf (>= 1.1) | debconf-2.0
+Depends: psmisc, adduser, libvulkan1, libatk1.0-0t64 (>= 1.12.4), libc6 (>= 2.38), libcairo-gobject2 (>= 1.10.0), libcairo2 (>= 1.2.4), libcurl4t64 (>= 7.16.2), libdbus-1-3 (>= 1.9.14), libfontconfig1 (>= 2.12.6), libfreetype6 (>= 2.9.1), libgcc-s1 (>= 3.4), libgdk-pixbuf-2.0-0 (>= 2.31.1), libgl1, libglib2.0-0t64 (>= 2.34.0), libgtk-3-0t64 (>= 3.21.5), libgtk2.0-0t64 (>= 2.24.0), liblzf1 (>= 1.5), liblzma5 (>= 5.1.1alpha+20120614), libpango-1.0-0 (>= 1.14.0), libpangocairo-1.0-0 (>= 1.14.0), libpangoft2-1.0-0 (>= 1.14.0), libpng16-16t64 (>= 1.6.2), libssl3t64 (>= 3.0.0), libstdc++6 (>= 13.1), libtpms0 (>= 0.8.0~dev1), libvpx9 (>= 1.12.0), libwayland-client0 (>= 1.11.0), libwayland-cursor0 (>= 1.8.1), libx11-6, libx11-xcb1 (>= 2:1.8.7), libxcb-cursor0 (>= 0.0.99), libxcb-icccm4 (>= 0.4.1), libxcb-image0 (>= 0.2.1), libxcb-keysyms1 (>= 0.4.0), libxcb-randr0 (>= 1.12), libxcb-render-util0, libxcb-render0, libxcb-shape0, libxcb-shm0 (>= 1.10), libxcb-sync1, libxcb-xfixes0, libxcb-xkb1, libxcb1 (>= 1.8), libxkbcommon-x11-0 (>= 0.5.0), libxkbcommon0 (>= 0.5.0), libxml2 (>= 2.7.4), libxt6t64, zlib1g (>= 1:1.2.3.4)
+Recommends: libasound2, libpulse0, libsdl-ttf2.0-0, kmod | kldutils | module-init-tools, linux-headers-generic | linux-headers-generic-pae | linux-headers-686-pae | linux-headers-amd64 | linux-headers-2.6-686 | linux-headers-2.6-amd64 | linux-headers, linux-image, gcc, make | build-essential | dpkg-dev, binutils, pdf-viewer
+Conflicts: virtualbox-ose
+Section: contrib/misc
+Priority: optional
+Description: Oracle VirtualBox
+ VirtualBox is a powerful PC virtualization solution allowing you to run a
+ wide range of PC operating systems on your Linux system. This includes
+ Windows, Linux, FreeBSD, DOS, OpenBSD and others. VirtualBox comes with a broad
+ feature set and excellent performance, making it the premier virtualization
+ software solution on the market.

--- a/assets/replace/resolute/main/binary-amd64/virtualbox/files/DEBIAN/control
+++ b/assets/replace/resolute/main/binary-amd64/virtualbox/files/DEBIAN/control
@@ -1,19 +1,17 @@
- Package: virtualbox-7.2
- Version: 7.2.14-174565~Ubuntu~resolute
- Architecture: amd64
- Maintainer: Oracle Corporation <info@virtualbox.org>
- Installed-Size: 241248
- Pre-Depends: debconf (>= 1.1) | debconf-2.0
- Depends: psmisc, adduser, libvulkan1, libc6 (>= 2.42), libcurl4t64 (>= 7.16.2), libgcc-s1 (>= 3.0), libgl1, libgsoap-2.8.139 (>= 2.8.139), liblzf1 (>= 1.5), liblzma5 (>= 5.1.1alpha+20120614), libpng16-16t64 (>= 1.6.46), libqt6core6t64 (>= 6.10.2), libqt6dbus6 (>= 6.1.2), libqt6gui6 (>= 6.9.1), libqt6help6 (>= 6.6.0), libqt6printsupport6 (>= 6.1.2), libqt6statemachine6 (>= 6.6.1), libqt6widgets6 (>= 6.10.2), libqt6xml6 (>= 6.6.0), libssl3t64 (>= 3.0.0), libstdc++6 (>= 14), libtpms0 (>= 0.8.0~dev1), libvpx12 (>= 1.16.0), libx11-6, libxcb1, libxml2-16 (>= 2.14.1), libxt6t64, zlib1g (>= 1:1.1.4)
- Recommends: libasound2, libpulse0, libsdl-ttf2.0-0, kmod | kldutils | module-init-tools, linux-headers-generic | linux-headers-generic-pae | linux-headers-686-pae | linux-headers-amd64 | linux-headers-2.6-686 | linux-headers-2.6-amd64 | linux-headers, linux-image, gcc, make | build-essential | dpkg-dev, binutils, pdf-viewer
- Conflicts: virtualbox, virtualbox-dkms, virtualbox-guest-additions-iso, virtualbox-ose, virtualbox-qt
- Replaces: virtualbox
- Provides: virtualbox
- Section: contrib/misc
- Priority: optional
- Description: Oracle VirtualBox
-  VirtualBox is a powerful PC virtualization solution allowing you to run a
-  wide range of PC operating systems on your Linux system. This includes
-  Windows, Linux, FreeBSD, DOS, OpenBSD and others. VirtualBox comes with a broad
-  feature set and excellent performance, making it the premier virtualization
-  software solution on the market.
+Package: virtualbox
+Version: 7.2.14-174565~Ubuntu~resolute
+Architecture: amd64
+Maintainer: Oracle Corporation <info@virtualbox.org>
+Installed-Size: 241248
+Pre-Depends: debconf (>= 1.1) | debconf-2.0
+Depends: Depends: psmisc, adduser, libvulkan1, libc6 (>= 2.42), libcurl4t64 (>= 7.16.2), libgcc-s1 (>= 3.0), libgl1, libgsoap-2.8.139 (>= 2.8.139), liblzf1 (>= 1.5), liblzma5 (>= 5.1.1alpha+20120614), libpng16-16t64 (>= 1.6.46), libqt6core6t64 (>= 6.10.2), libqt6dbus6 (>= 6.1.2), libqt6gui6 (>= 6.9.1), libqt6help6 (>= 6.6.0), libqt6printsupport6 (>= 6.1.2), libqt6statemachine6 (>= 6.6.1), libqt6widgets6 (>= 6.10.2), libqt6xml6 (>= 6.6.0), libssl3t64 (>= 3.0.0), libstdc++6 (>= 14), libtpms0 (>= 0.8.0~dev1), libvpx12 (>= 1.16.0), libx11-6, libxcb1, libxml2-16 (>= 2.14.1), libxt6t64, zlib1g (>= 1:1.1.4)
+Recommends: libasound2, libpulse0, libsdl-ttf2.0-0, kmod | kldutils | module-init-tools, linux-headers-generic | linux-headers-generic-pae | linux-headers-686-pae | linux-headers-amd64 | linux-headers-2.6-686 | linux-headers-2.6-amd64 | linux-headers, linux-image, gcc, make | build-essential | dpkg-dev, binutils, pdf-viewer
+Conflicts: virtualbox-ose
+Section: contrib/misc
+Priority: optional
+Description: Oracle VirtualBox
+ VirtualBox is a powerful PC virtualization solution allowing you to run a
+ wide range of PC operating systems on your Linux system. This includes
+ Windows, Linux, FreeBSD, DOS, OpenBSD and others. VirtualBox comes with a broad
+ feature set and excellent performance, making it the premier virtualization
+ software solution on the market.


### PR DESCRIPTION
Reverts the package name changes (and extraneous leading spaces) from https://github.com/pop-os/repo-curated-free/pull/18.